### PR TITLE
add redux devtools extension as a redux store enhancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Botghani Notepad
+
+A React-native list-creating app.
+
+## Table of Contents
+
+1. [Development](#development)
+   * [Setup](#setup)
+   * [Running](#running)
+   * [Development Tools](#development-tools)
+
+
+## Development
+### Setup
+
+    yarn install
+
+**[Back to top](#table-of-contents)**
+
+### Running
+
+To run the application on an iphone simulator (like Xcode):
+
+    react-native run-ios
+
+**[Back to top](#table-of-contents)**
+
+### Development tools
+
+#### React Native Debugger
+React Native Debugger is a standalone app that allows for easy debugging of React Native apps.
+
+To install the app: `brew cask install react-native-debugger` (you may need to run `brew update` beforehand)
+
+Before opening the app, ensure that no other React-native debugger is open.
+
+To open the app: `yarn rnd`
+
+**[Back to top](#table-of-contents)**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
-    "react-devtools": "react-devtools"
+    "react-devtools": "react-devtools",
+    "rnd": "open 'rndebugger://set-debugger-loc?host=localhost&port=8081'"
   },
   "dependencies": {
     "react": "16.3.1",

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,6 +1,9 @@
 import { createStore } from 'redux'
 import globalReducer from './reducers/globalReducer'
 
-const store = createStore(globalReducer)
+const store = createStore(
+  globalReducer,
+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+)
 
 export default store


### PR DESCRIPTION
The standalone app 'React Native Debugger' includes Redux DevTools.

Once the 'React Native Debugger' app is installed (see README#development-tools for installation steps), it can be used to easily inspect the redux state and actions of the main app.

closes #31