### PR TITLE
set targetfolder to empty string when no argument passed

### DIFF
--- a/scripts/component.js
+++ b/scripts/component.js
@@ -27,7 +27,7 @@ if (!name) {
 name = changeCase.pascal(name)
 
 let targetfolder = argv._[1]
-targetfolder = targetfolder ? `${formatComponentName(targetfolder)}/` : console.error('You forgot to provide an argument to the create-ui script') 
+targetfolder = targetfolder ? `${formatComponentName(targetfolder)}/` : ''
 
 const cwd = process.cwd()
 const dir = path.resolve(__dirname, [COMPONENTS_FOLDER, targetfolder, name].join(''))


### PR DESCRIPTION
@deefourple You were right about setting the `targetfolder` to an empty string if an argument was not passed. I didn't realize what the point of it was until now: it gets tacked onto the new component path if it is provided, and if it's not provided then it won't have any affect on `path.resolve` as an empty string.