### PR TITLE
add horizontal scrolling to a table

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -1,8 +1,7 @@
 import React  from 'react'
-import { View } from 'react-native'
+import { View, ScrollView } from 'react-native'
 import PropTypes from 'prop-types'
 import { generateFirstColumn, getCells, generateColumn } from '../../utils/table'
-import { moveFirstColumnToHead } from '../../utils/moveToHead'
 
 import Cell from './Cell'
 
@@ -20,14 +19,29 @@ Column.propTypes = {
 const Table = ({ list }) =>
   <View style={ustyle.fr1}>
     {
-      moveFirstColumnToHead(list.columns).map((column) => {
+      list.columns.map((column) => {
         if (column.isFirstColumn) {
-          return <Column key={column.id} listId={list.id} cells={generateFirstColumn(column, list.rows)} />
+          return (
+            <View style={ustyle.autoWidth}>
+              <Column key={column.id} listId={list.id} cells={generateFirstColumn(column, list.rows)} />
+            </View>
+          )
         }
 
-        return <Column key={column.id} listId={list.id} cells={generateColumn(column, list.rows, list.cells)} />
+        return null
       })
     }
+    <ScrollView style={ustyle.fr1} horizontal>
+      {
+        list.columns.map((column) => {
+          if (column.isFirstColumn) {
+            return null
+          }
+
+          return <Column key={column.id} listId={list.id} cells={generateColumn(column, list.rows, list.cells)} />
+        })
+      }
+    </ScrollView>
   </View>
 
 Table.propTypes = {

--- a/src/utils/style.js
+++ b/src/utils/style.js
@@ -6,4 +6,5 @@ export default StyleSheet.create({
   fc: { flexDirection: 'column' },
   fr1: { flex: 1, flexDirection: 'row' },
   fc1: { flex: 1, flexDirection: 'column' },
+  autoWidth: { width: 'auto' }
 })


### PR DESCRIPTION
React-Native does not have a way of stickying elements in a horizontal ScrollView. the ScrollView property 'stickyHeaderIndices' only works for vertical ScrollViews.
As a solution, the first column in each table is manually "stickied" to the left by being rendered outside of the ScrollView.

closes #79