### PR TITLE
enable jsx for expo-cli v3

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,6 +17,9 @@
     ],
     "ios": {
       "supportsTablet": true
+    },
+    "packagerOpts": {
+      "sourceExts": ["js", "json", "jsx"]
     }
   }
 }


### PR DESCRIPTION
This is a fix for upgrading expo-cli to v3.x.x because it currently
contains a bug that prevents the app from loading due to the inability
to resolve jsx files.

Solution found here:

https://github.com/expo/expo-cli/issues/191#issuecomment-515041409