### PR TITLE
Release 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botghani-notepad",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A simple, elegant, and generation shaping 2D list mobile application",
   "private": true,
   "contributors": [

--- a/src/utils/CHANGELOG.md
+++ b/src/utils/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2019-10-20
+
+### Initial release! :tada:
+
+### Added
+- Add ability to create a list
+- Add ability to view a list of all created lists
+- Add ability to view a list
+- Add ability to add items to a list
+- Add ability to add sub-categories and sub-items to a list
+- Add ability to edit a list
+- Add ability to delete a list
+- Add ability to set a favourite list that is opened when launching the app


### PR DESCRIPTION
@deefourple I figured before we transition into the updated version of the app, let's release the existing version as a sort of "alpha" version, `v0.1.0`. Then when we finish the MVP of the updated version, it can be `v1.0.0`. I made a changelog so we can keep track of features and bug fixes when the app takes off 😉 